### PR TITLE
Fix version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sigparse"
-version = "1.0.0"
+version = "3.0.0"
 description = "Backports python3.10 typing features into python 3.7 and newer."
 authors = ["Lunarmagpie <bambolambo0@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
version in `pyproject.toml` is not synced wth actual release.
I got an error due to `sigparse` being at version `1.0.0` while installing hikari-crescent :sweat_smile: 

